### PR TITLE
Fix jenkins setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Released]
 
-## [2.0] - 2024-07-17
+## [2.0.0] - 2024-07-17
 - Vue dependency updated to v3, with behind-the-scenes changes to adopt composition API
 
 [Released]: https://github.com/DOI-USGS/gages-through-the-ages

--- a/jenkins/Jenkinsfile.build
+++ b/jenkins/Jenkinsfile.build
@@ -29,7 +29,7 @@ pipeline {
                           extensions: [],
                           gitTool: 'Default',
                           submoduleCfg: [],
-                          userRemoteConfigs: [[url: "https://github.com/DOI-USGS/${params.VITE_APP_TITLE}.git", credentialsId: "vizlab_jenkins_${params.VITE_APP_TITLE}"]]
+                          userRemoteConfigs: [[url: "https://github.com/DOI-USGS/${params.VITE_APP_TITLE}.git"]]
                         ])
                 }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gages-through-the-ages",
-  "version": "2.0",
+  "version": "2.0.0",
   "private": true,
   "scripts": {
     "dev": "vite --mode test_tier",


### PR DESCRIPTION
This is a minor PR that does not affect site content or the site build. It just:
* updates the version number to match past versioning
* drops credentials information from the jenkins setup, since it is unused with a GitHub repo