### PR TITLE
Fix accordions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Released]
 
-## [2.0] - 2024-07-17
+## [2.0.0] - 2024-07-17
 - Vue dependency updated to v3, with behind-the-scenes changes to adopt composition API
 
 [Released]: https://github.com/DOI-USGS/gages-through-the-ages

--- a/jenkins/Jenkinsfile.build
+++ b/jenkins/Jenkinsfile.build
@@ -29,7 +29,7 @@ pipeline {
                           extensions: [],
                           gitTool: 'Default',
                           submoduleCfg: [],
-                          userRemoteConfigs: [[url: "https://github.com/DOI-USGS/${params.VITE_APP_TITLE}.git", credentialsId: "vizlab_jenkins_${params.VITE_APP_TITLE}"]]
+                          userRemoteConfigs: [[url: "https://github.com/DOI-USGS/${params.VITE_APP_TITLE}.git"]]
                         ])
                 }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gages-through-the-ages",
-  "version": "2.0",
+  "version": "2.0.0",
   "private": true,
   "scripts": {
     "dev": "vite --mode test_tier",

--- a/src/components/MethodsSection.vue
+++ b/src/components/MethodsSection.vue
@@ -22,6 +22,7 @@
         <div
           :id="method.title"
           class="usa-accordion__content usa-prose gage-target"
+          hidden
         >
           <p><span v-html="method.method" /></p>
         </div>

--- a/src/components/NewTimeline.vue
+++ b/src/components/NewTimeline.vue
@@ -239,6 +239,7 @@
         <div
           :id="method.title"
           class="usa-accordion__content usa-prose gage-target"
+          hidden
         >
           <h3
             v-if="windowWidth > 770"

--- a/src/components/WorkInProgressWarning.vue
+++ b/src/components/WorkInProgressWarning.vue
@@ -38,7 +38,7 @@
     button {
       display: block;
       margin: 0 auto;
-      background: var(--color-USGS-header-footer);
+      background: #00264c;
       color: #ffffff;
       border: none;
       outline: none;


### PR DESCRIPTION
Small MR to 1) Fix bug where the timeline and methods accordions were open on page load, and 2) fix the styling of the work-in-progress button.

previously:

![image](https://github.com/user-attachments/assets/c1739116-3072-434f-8e54-f9ba183a4dbb)

now:

![image](https://github.com/user-attachments/assets/f7b67650-42b3-4f6d-9371-c46e204da5db)

To test:
* Unfortunately this can only be tested by building the site locally with `npm run build-beta`, then dropping the content in the newly created `dist` dir into `dist/visualizations/gages-through-the-ages` (you have to make those two subdirectories). Then you can preview the site in R by setting the working directory to this repo, then running `servr::httd('dist')`, entering the produced local address into your browser, and clicking on the menu that appears to get to 'visualizations/gages-through-the-ages'