### PR TITLE
Fix slider

### DIFF
--- a/src/components/GagesBarChartAnimation.vue
+++ b/src/components/GagesBarChartAnimation.vue
@@ -5685,13 +5685,6 @@ $brightYellow: rgb(255,200,51);
     }
     .clear{clear: both;}
   }
-  /*IE SVG Width Fix*/
-  @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-    #gage-map figure {
-      width: 100%;
-      height: 506px;
-    }
-  }
   /*Text version of information captured by infographic
   This class leaves it in the site for a screen reader 
   but hides it from view*/

--- a/src/components/MapImageSlider.vue
+++ b/src/components/MapImageSlider.vue
@@ -1977,7 +1977,9 @@ $polygon: '@/assets/images/polygon.png';
     border-left: 2px solid #fff;
     border-top: 2px solid #fff;
 }
-
+.beer-range {
+  -webkit-appearance: sliderthumb-horizontal !important;
+}
 .beer-range:focus ~ .beer-handle {
     background: $brightBlue;
 }


### PR DESCRIPTION
This PR makes a minor edit to the css associated with the map slider to override a setting in the `beerslider` package - it was using `-webkit-appearance: slider-horizontal !important;`. `slider-horizontal` is deprecated. I updated the value by setting the css explicitly in `MapImageSlider.vue`:

```
.beer-range {
  -webkit-appearance: sliderthumb-horizontal !important;
}
```

I also fixed another console warning about `-ms-high-contrast:` by dropping a css fix for Internet Explorer in `GagesBarChartAnimation.vue`, since we no longer support internet explorer.

Hopefully this addresses the slider issue in Safari! 🤞🤞